### PR TITLE
fix: PsaList::paxReference

### DIFF
--- a/src/Amadeus/Client/Struct/Ticket/CreateTSTFromPricing.php
+++ b/src/Amadeus/Client/Struct/Ticket/CreateTSTFromPricing.php
@@ -90,7 +90,7 @@ class CreateTSTFromPricing extends BaseWsMessage
             $list->paxReference = $this->makePaxRef($pricing->passengerReferences);
         }
 
-        return $list;
+        return new \SoapVar($list, SOAP_ENC_OBJECT);
     }
 
     /**

--- a/tests/Amadeus/Client/Struct/Ticket/CreateTSMFromPricingTest.php
+++ b/tests/Amadeus/Client/Struct/Ticket/CreateTSMFromPricingTest.php
@@ -42,12 +42,12 @@ class CreateTSMFromPricingTest extends BaseTestCase
         );
 
         $this->assertEquals(1, count($msg->psaList));
-        $this->assertEquals(2, $msg->psaList[0]->itemReference->uniqueReference);
-        $this->assertEquals(ItemReference::REFTYPE_TSM, $msg->psaList[0]->itemReference->referenceType);
+        $this->assertEquals(2, $msg->psaList[0]->enc_value->itemReference->uniqueReference);
+        $this->assertEquals(ItemReference::REFTYPE_TSM, $msg->psaList[0]->enc_value->itemReference->referenceType);
 
-        $this->assertEquals(1, count($msg->psaList[0]->paxReference->refDetails));
-        $this->assertEquals(1, $msg->psaList[0]->paxReference->refDetails[0]->refNumber);
-        $this->assertEquals(RefDetails::QUAL_PASSENGER, $msg->psaList[0]->paxReference->refDetails[0]->refQualifier);
+        $this->assertEquals(1, count($msg->psaList[0]->enc_value->paxReference->refDetails));
+        $this->assertEquals(1, $msg->psaList[0]->enc_value->paxReference->refDetails[0]->refNumber);
+        $this->assertEquals(RefDetails::QUAL_PASSENGER, $msg->psaList[0]->enc_value->paxReference->refDetails[0]->refQualifier);
     }
 
     public function testCanMakeTsmFromPricingWithPnrInfo()

--- a/tests/Amadeus/Client/Struct/Ticket/CreateTSTFromPricingTest.php
+++ b/tests/Amadeus/Client/Struct/Ticket/CreateTSTFromPricingTest.php
@@ -57,12 +57,12 @@ class CreateTSTFromPricingTest extends BaseTestCase
         );
 
         $this->assertCount(1, $msg->psaList);
-        $this->assertEquals(3, $msg->psaList[0]->itemReference->uniqueReference);
-        $this->assertEquals(ItemReference::REFTYPE_TST, $msg->psaList[0]->itemReference->referenceType);
+        $this->assertEquals(3, $msg->psaList[0]->enc_value->itemReference->uniqueReference);
+        $this->assertEquals(ItemReference::REFTYPE_TST, $msg->psaList[0]->enc_value->itemReference->referenceType);
 
-        $this->assertCount(1, $msg->psaList[0]->paxReference->refDetails);
-        $this->assertEquals(1, $msg->psaList[0]->paxReference->refDetails[0]->refNumber);
-        $this->assertEquals(RefDetails::QUAL_ADULT, $msg->psaList[0]->paxReference->refDetails[0]->refQualifier);
+        $this->assertCount(1, $msg->psaList[0]->enc_value->paxReference->refDetails);
+        $this->assertEquals(1, $msg->psaList[0]->enc_value->paxReference->refDetails[0]->refNumber);
+        $this->assertEquals(RefDetails::QUAL_ADULT, $msg->psaList[0]->enc_value->paxReference->refDetails[0]->refQualifier);
     }
 
     public function testCanMakeMultiTstFromPricing()
@@ -85,15 +85,59 @@ class CreateTSTFromPricingTest extends BaseTestCase
         );
 
         $this->assertEquals(3, count($msg->psaList));
-        $this->assertEquals(1, $msg->psaList[0]->itemReference->uniqueReference);
-        $this->assertEquals(ItemReference::REFTYPE_TST, $msg->psaList[0]->itemReference->referenceType);
-        $this->assertNull($msg->psaList[0]->paxReference);
-        $this->assertEquals(2, $msg->psaList[1]->itemReference->uniqueReference);
-        $this->assertEquals(ItemReference::REFTYPE_TST, $msg->psaList[1]->itemReference->referenceType);
-        $this->assertNull($msg->psaList[1]->paxReference);
-        $this->assertEquals(3, $msg->psaList[2]->itemReference->uniqueReference);
-        $this->assertEquals(ItemReference::REFTYPE_TST, $msg->psaList[2]->itemReference->referenceType);
-        $this->assertNull($msg->psaList[2]->paxReference);
+        $this->assertEquals(1, $msg->psaList[0]->enc_value->itemReference->uniqueReference);
+        $this->assertEquals(ItemReference::REFTYPE_TST, $msg->psaList[0]->enc_value->itemReference->referenceType);
+        $this->assertNull($msg->psaList[0]->enc_value->paxReference);
+        $this->assertEquals(2, $msg->psaList[1]->enc_value->itemReference->uniqueReference);
+        $this->assertEquals(ItemReference::REFTYPE_TST, $msg->psaList[1]->enc_value->itemReference->referenceType);
+        $this->assertNull($msg->psaList[1]->enc_value->paxReference);
+        $this->assertEquals(3, $msg->psaList[2]->enc_value->itemReference->uniqueReference);
+        $this->assertEquals(ItemReference::REFTYPE_TST, $msg->psaList[2]->enc_value->itemReference->referenceType);
+        $this->assertNull($msg->psaList[2]->enc_value->paxReference);
+    }
+
+
+    public function testMakePsaListWrapsPsaListInSoapVar()
+    {
+        $msg = new CreateTSTFromPricing(
+            new TicketCreateTstFromPricingOptions([
+                'pricings' => [
+                    new Pricing([
+                        'tstNumber' => 1,
+                    ]),
+                    new Pricing([
+                        'tstNumber' => 2,
+                        'passengerReferences' => [
+                            new PassengerReference([
+                                'id' => 1,
+                                'type' => PassengerReference::TYPE_ADULT,
+                            ]),
+                        ],
+                    ]),
+                ],
+            ])
+        );
+
+        $this->assertInstanceOf('\SoapVar', $msg->psaList[0]);
+        $this->assertEquals(SOAP_ENC_OBJECT, $msg->psaList[0]->enc_type);
+        $this->assertNull($msg->psaList[0]->enc_name);
+        $this->assertNull($msg->psaList[0]->enc_namens);
+        $this->assertInstanceOf('\Amadeus\Client\Struct\Ticket\PsaList', $msg->psaList[0]->enc_value);
+        $this->assertEquals(1, $msg->psaList[0]->enc_value->itemReference->uniqueReference);
+        $this->assertNull($msg->psaList[0]->enc_value->paxReference);
+
+        $this->assertInstanceOf('\SoapVar', $msg->psaList[1]);
+        $this->assertEquals(SOAP_ENC_OBJECT, $msg->psaList[1]->enc_type);
+        $this->assertInstanceOf('\Amadeus\Client\Struct\Ticket\PsaList', $msg->psaList[1]->enc_value);
+        $this->assertCount(1, $msg->psaList[1]->enc_value->paxReference->refDetails);
+        $this->assertEquals(
+            RefDetails::QUAL_ADULT,
+            $msg->psaList[1]->enc_value->paxReference->refDetails[0]->refQualifier
+        );
+        $this->assertEquals(
+            1,
+            $msg->psaList[1]->enc_value->paxReference->refDetails[0]->refNumber
+        );
     }
 
 


### PR DESCRIPTION

	
	PsaList::paxReference не сериализовался в SOAP из-за анонимного complexType

	Причина: PHP SoapClient при сериализации анонимных комплексных типов
	(без name="..." в WSDL) дропает необязательные элементы (minOccurs="0").
	paxReference объявлен с minOccurs="0" и устанавливается после конструктора,
	поэтому молча терялся при сериализации.
	
	Решение: обернуть PsaList в SoapVar(SOAP_ENC_OBJECT) — это даёт сериализатору
	явную инструкцию сериализовать объект «как есть», минуя WSDL-резолвинг.
	Паттерн уже используется в проекте для SOAP-хедеров (Security, UsernameToken).
	
	Изменения:
	- CreateTSTFromPricing::makePsaList() — возвращает SoapVar вместо PsaList
	- Тесты адаптированы: доступ к свойствам через ->enc_value
	- Добавлен тест testMakePsaListWrapsPsaListInSoapVar
	
	Фикс покрывает Ticket_CreateTSTFromPricing и Ticket_CreateTSMFromPricing.
	DeleteTST использует PsaList напрямую и этим патчем не чинится (отдельный баг).